### PR TITLE
Adjust usleep to 500

### DIFF
--- a/client.c
+++ b/client.c
@@ -22,12 +22,12 @@ int	transmitter(pid_t pid, const char *message)
 		i = 0;
 		while (i < 8)
 		{
-			if (*message & (0x01 << i))
-				kill(pid, SIGUSR1);
-			else
-				kill(pid, SIGUSR2);
-			usleep(50);
-			i++;
+					if (*message & (0x01 << i))
+			kill(pid, SIGUSR1);
+		else
+			kill(pid, SIGUSR2);
+		usleep(500);
+		i++;
 		}
 		message++;
 	}

--- a/client_bonus.c
+++ b/client_bonus.c
@@ -22,12 +22,12 @@ int	transmitter(pid_t pid, const char *message)
 		i = 0;
 		while (i < 8)
 		{
-			if (*message & (0x01 << i))
-				kill(pid, SIGUSR1);
-			else
-				kill(pid, SIGUSR2);
-			usleep(50);
-			i++;
+					if (*message & (0x01 << i))
+			kill(pid, SIGUSR1);
+		else
+			kill(pid, SIGUSR2);
+		usleep(500);
+		i++;
 		}
 		message++;
 	}


### PR DESCRIPTION
Increase `usleep` delay to 500 microseconds in client files as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa4fe3dc-1a66-4eb6-99c6-c6f6f8a16336">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa4fe3dc-1a66-4eb6-99c6-c6f6f8a16336">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

